### PR TITLE
add test, fix examples and other misc house keeping

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react", "es2015"]
-}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-# 4 space indentation
-[*.js]
-indent_style = space
-indent_size = 4
-[*.jsx]
-indent_style = space
-indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,18 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "4.2"
-  - "5.0"
-
-# Directories we want to cache between each build
+  - "4"
+  - "5"
 cache:
   apt: true
   directories:
     - 'node_modules'
-
-# Addons we want to set up
 addons:
-
-  # System install
   apt:
     sources:
-    - 'ubuntu-toolchain-r-test'
+      - 'ubuntu-toolchain-r-test'
     packages:
-    - 'gcc-4.8'
-    - 'g++-4.8'
-
-# Environment variables we want to set
+      - 'gcc-4.8'
+      - 'g++-4.8'
 env:
   - 'CXX=g++-4.8'

--- a/examples/layout/server.js
+++ b/examples/layout/server.js
@@ -3,6 +3,11 @@ var Vision = require('vision');
 var HapiReactViews = require('../..');
 
 
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
+
+
 var server = new Hapi.Server();
 server.connection();
 server.register(Vision, function (err) {

--- a/examples/remount/server.js
+++ b/examples/remount/server.js
@@ -5,7 +5,9 @@ var Vision = require('vision');
 var HapiReactViews = require('../..');
 
 
-require('babel/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
 
 var server = new Hapi.Server();

--- a/examples/remount/webpack.js
+++ b/examples/remount/webpack.js
@@ -10,8 +10,12 @@ module.exports = {
         filename: Path.join(__dirname, './assets/client.js')
     },
     module: {
-        loaders: [
-            { test: /\.jsx$/, loader: 'babel-loader', presets: ['react', 'es2015'] }
-        ]
+        loaders: [{
+            test: /\.jsx$/,
+            loader: 'babel-loader',
+            query: {
+                presets: ['react', 'es2015']
+            }
+        }]
     }
 };

--- a/examples/simple/server.js
+++ b/examples/simple/server.js
@@ -3,7 +3,9 @@ var Vision = require('vision');
 var HapiReactViews = require('../..');
 
 
-require('babel/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
 
 var server = new Hapi.Server();

--- a/test/fixtures/view-es6.jsx
+++ b/test/fixtures/view-es6.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+
+class Component extends React.Component {
+
+    render () {
+
+        return (
+            <html>
+                <head>
+                    <title>{this.props.title}</title>
+                </head>
+                <body>
+                    <p>Activate the plot device.</p>
+                </body>
+            </html>
+        );
+    }
+}
+
+
+export default Component;

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,9 @@ var Vision = require('vision');
 var HapiReactViews = require('../index');
 
 
-require('babel-core/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
 
 var lab = exports.lab = Lab.script();
@@ -66,6 +68,18 @@ lab.experiment('Rendering', function () {
         var context = { title: 'Woot, it rendered.' };
 
         server.render('view', context, function (err, output) {
+
+            Code.expect(err).to.not.exist();
+            done();
+        });
+    });
+
+
+    lab.test('it successfully renders with es6 export semantics', function (done) {
+
+        var context = { title: 'Woot, it rendered.' };
+
+        server.render('view-es6', context, function (err, output) {
 
             Code.expect(err).to.not.exist();
             done();


### PR DESCRIPTION
I'd rather not add a `.babelrc` file to the root of the repo. We can set these things inline. In the same spirit I'm removing the `.editorconfig` file while we're at it.

We should limit our travis tests to just node `4` and `5`, which will give us the latest stable version of each.

I also updated to the examples to make sure they're still working.

I also added a test to demonstrate the es6 export semantics originally addressed in your PR.

Once you merge this, these changes will automatically show up in https://github.com/jedireza/hapi-react-views/pull/32